### PR TITLE
Better transactions

### DIFF
--- a/etherlite.gemspec
+++ b/etherlite.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "eth", "~> 0.4.4"
   spec.add_dependency "activesupport"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "guard", "~> 2.14"
   spec.add_development_dependency "guard-rspec", "~> 4.7"
-  spec.add_development_dependency "webmock", "~> 3.0.1"
+  spec.add_development_dependency "webmock", "~> 3.7.5"
   spec.add_development_dependency "pry"
 end

--- a/lib/etherlite/account/private_key.rb
+++ b/lib/etherlite/account/private_key.rb
@@ -9,7 +9,11 @@ module Etherlite
       end
 
       def send_transaction(_options = {})
-        nonce_manager.with_next_nonce_for(normalized_address) do |nonce|
+        nonce_options = {
+          replace: _options.fetch(:replace, false)
+        }
+
+        nonce_manager.with_next_nonce_for(normalized_address, nonce_options) do |nonce|
           tx = Eth::Tx.new(
             value: _options.fetch(:value, 0),
             data: _options.fetch(:data, ''),

--- a/lib/etherlite/nonce_manager.rb
+++ b/lib/etherlite/nonce_manager.rb
@@ -17,9 +17,10 @@ module Etherlite
       last_nonce
     end
 
-    def with_next_nonce_for(_normalized_address)
+    def with_next_nonce_for(_normalized_address, replace: false)
       @@nonce_mutex.synchronize do
-        next_nonce = last_nonce_for(_normalized_address) + 1
+        next_nonce = last_nonce_for(_normalized_address)
+        next_nonce += 1 if next_nonce.negative? || !replace # if first tx, don't replace
 
         begin
           result = yield next_nonce

--- a/spec/account/private_key_spec.rb
+++ b/spec/account/private_key_spec.rb
@@ -52,6 +52,19 @@ describe Etherlite::Account::PrivateKey do
       expect(tx.tx_hash).to eq 'a_hash'
     end
 
+    it "calls 'eth_send_raw_transaction' with previous nonce if 'replace' option is given" do
+      expect(connection).to receive(:eth_send_raw_transaction) do |raw|
+        tx = Eth::Tx.decode raw
+        expect(tx.nonce).to eq tx_count - 1
+
+        'a_hash'
+      end
+
+      account.send_transaction(
+        to: target_address, data: data, value: amount, gas: gas_limit, replace: true
+      )
+    end
+
     context "when use_parity flag is set to true" do
       before do
         allow(connection).to receive(:use_parity).and_return true

--- a/spec/integration/node_functions_spec.rb
+++ b/spec/integration/node_functions_spec.rb
@@ -61,9 +61,9 @@ describe 'Test node functions against testrpc', integration: true do
       end
 
       it "returns an transaction object that can be queried for transaction confirmations" do
-        expect(client.load_transaction(hash).refresh.confirmations).to eq 0
-        client.connection.evm_mine
         expect(client.load_transaction(hash).refresh.confirmations).to eq 1
+        client.connection.evm_mine
+        expect(client.load_transaction(hash).refresh.confirmations).to eq 2
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,5 +24,8 @@ module SpecExtensions
 end
 
 RSpec.configure do |config|
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+  
   config.include SpecExtensions
 end


### PR DESCRIPTION
This PR improves the way transaction information is retrieved (it was wrong and incomplete)

This PR also adds the replace option to the `PrivateKey.send_transaction` method, to allow replacing an already sent transaction.


