### PR TITLE
gems: rename sha3 to keccak

### DIFF
--- a/etherlite.gemspec
+++ b/etherlite.gemspec
@@ -19,16 +19,16 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "digest-sha3", "~> 1.1"
-  spec.add_dependency "power-types", "~> 0.1"
-  spec.add_dependency "eth", "~> 0.4.4"
-  spec.add_dependency "activesupport"
+  spec.add_dependency "keccak", "~> 1.1"
+  spec.add_dependency "power-types", "~> 0.4"
+  spec.add_dependency "eth", "~> 0.4"
+  spec.add_dependency "activesupport", "~> 6.1"
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "guard", "~> 2.14"
+  spec.add_development_dependency "bundler", "~> 2.2"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.10"
+  spec.add_development_dependency "guard", "~> 2.18"
   spec.add_development_dependency "guard-rspec", "~> 4.7"
-  spec.add_development_dependency "webmock", "~> 3.7.5"
-  spec.add_development_dependency "pry"
+  spec.add_development_dependency "webmock", "~> 3.14"
+  spec.add_development_dependency "pry", "~> 0.14"
 end

--- a/lib/etherlite.rb
+++ b/lib/etherlite.rb
@@ -1,4 +1,4 @@
-require "digest/sha3"
+require "digest/keccak"
 require "active_support/all"
 require "forwardable"
 require "net/http"

--- a/lib/etherlite/commands/utils/validate_address.rb
+++ b/lib/etherlite/commands/utils/validate_address.rb
@@ -12,7 +12,7 @@ module Etherlite::Utils
 
     def valid_checksum?
       trimmed_address = @address.gsub(/^0x/, '')
-      address_hash = Etherlite::Utils.sha3 trimmed_address.downcase
+      address_hash = Etherlite::Utils.keccak trimmed_address.downcase
 
       trimmed_address.chars.each_with_index do |c, i|
         hash_byte = address_hash[i].to_i(16)

--- a/lib/etherlite/contract/event_base.rb
+++ b/lib/etherlite/contract/event_base.rb
@@ -18,7 +18,7 @@ module Etherlite::Contract
     end
 
     def self.topic
-      '0x' + Etherlite::Utils.sha3(signature)
+      '0x' + Etherlite::Utils.keccak(signature)
     end
 
     def self.decode(_connection, _json)

--- a/lib/etherlite/contract/function.rb
+++ b/lib/etherlite/contract/function.rb
@@ -34,7 +34,7 @@ module Etherlite::Contract
       encoded_inputs = Etherlite::Support::Array.encode(@inputs.map(&:type), _values)
 
       if @name
-        signature_hash = Etherlite::Utils.sha3 signature
+        signature_hash = Etherlite::Utils.keccak signature
         '0x' + signature_hash[0..7] + encoded_inputs
       else
         encoded_inputs # if no name is provided, just render arguments

--- a/lib/etherlite/utils.rb
+++ b/lib/etherlite/utils.rb
@@ -4,8 +4,8 @@ module Etherlite
   module Utils
     extend self
 
-    def sha3(_data)
-      Digest::SHA3.hexdigest(_data, 256)
+    def keccak(_data)
+      Digest::Keccak.hexdigest(_data, 256)
     end
 
     def uint_to_hex(_value, bytes: 32)


### PR DESCRIPTION
replaces digest-sha3 to enable support for ruby 2.3 and later
* ref https://github.com/q9f/keccak.rb/pull/16