### PR TITLE
chore(etherlite.gemspec): replace old digest-sha3 gem with keccak

### DIFF
--- a/etherlite.gemspec
+++ b/etherlite.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'etherlite/version'
 
@@ -9,26 +8,28 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Ignacio Baixas"]
   spec.email         = ["ignacio@surbtc.com"]
 
-  spec.summary       = %q{Ethereum integration for ruby on rails}
-  spec.description   = %q{}
+  spec.summary       = 'Ethereum integration for ruby on rails'
+  spec.description   = ''
   spec.homepage      = "https://github.com/SurBTC/etherlite"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "digest-sha3", "~> 1.1"
-  spec.add_dependency "power-types", "~> 0.1"
-  spec.add_dependency "eth", "~> 0.4.4"
   spec.add_dependency "activesupport"
+  spec.add_dependency "eth", "~> 0.4.4"
+  spec.add_dependency 'keccak', '~> 1.3', '>= 1.3.1'
+  spec.add_dependency "power-types", "~> 0.1"
 
   spec.add_development_dependency "bundler", "~> 2.1.4"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "guard", "~> 2.14"
   spec.add_development_dependency "guard-rspec", "~> 4.7"
-  spec.add_development_dependency "webmock", "~> 3.7.5"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 3.7.5"
 end

--- a/lib/etherlite.rb
+++ b/lib/etherlite.rb
@@ -1,4 +1,4 @@
-require "digest/sha3"
+require 'digest/keccak'
 require "active_support/all"
 require "forwardable"
 require "net/http"

--- a/lib/etherlite/utils.rb
+++ b/lib/etherlite/utils.rb
@@ -5,7 +5,7 @@ module Etherlite
     extend self
 
     def sha3(_data)
-      Digest::SHA3.hexdigest(_data, 256)
+      Digest::Keccak.hexdigest(_data, 256)
     end
 
     def uint_to_hex(_value, bytes: 32)
@@ -13,7 +13,7 @@ module Etherlite
     end
 
     def int_to_hex(_value, bytes: 32)
-      if _value < 0
+      if _value.negative?
         # 2's complement for negative values
         (_value & ((1 << bytes * 8) - 1)).to_s(16)
       else
@@ -28,7 +28,7 @@ module Etherlite
     def hex_to_int(_hex_value, bytes: 32)
       value = _hex_value.hex
       top_bit = (1 << (bytes * 8 - 1))
-      value & top_bit > 0 ? (value - 2 * top_bit) : value
+      (value & top_bit).positive? ? (value - 2 * top_bit) : value
     end
 
     def valid_address?(_address)
@@ -45,21 +45,23 @@ module Etherlite
       else
         _value = _value.to_s
         raise ArgumentError, 'invalid address' unless valid_address? _value
+
         normalize_address _value
       end
     end
 
     def encode_address_param(_value)
-      '0x' + normalize_address_param(_value)
+      "0x#{normalize_address_param(_value)}"
     end
 
     def encode_block_param(_value)
       return _value.to_s if ['pending', 'earliest', 'latest'].include?(_value.to_s)
-      '0x' + _value.to_s(16)
+
+      "0x#{_value.to_s(16)}"
     end
 
     def encode_quantity_param(_value)
-      '0x' + _value.to_s(16)
+      "0x#{_value.to_s(16)}"
     end
   end
 end


### PR DESCRIPTION
Cambia la dependencia de [digest-sha3](https://github.com/phusion/digest-sha3-ruby) a [keccak](https://github.com/q9f/keccak.rb) que es una gema mucho más actualizada. Esto en principio para no trabar la compatibilidad con ruby 3.