### PR TITLE
Actualiza gema eth a versión 0.5.10

### DIFF
--- a/etherlite.gemspec
+++ b/etherlite.gemspec
@@ -3,33 +3,33 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'etherlite/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "etherlite"
+  spec.name          = 'etherlite'
   spec.version       = Etherlite::VERSION
-  spec.authors       = ["Ignacio Baixas"]
-  spec.email         = ["ignacio@budacom.com"]
+  spec.authors       = ['Ignacio Baixas']
+  spec.email         = ['ignacio@budacom.com']
 
   spec.summary       = 'Ethereum integration for ruby on rails'
   spec.description   = ''
-  spec.homepage      = "https://github.com/budacom/etherlite"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/budacom/etherlite'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_dependency "activesupport"
-  spec.add_dependency "eth", "~> 0.4.4"
+  spec.add_dependency 'activesupport'
+  spec.add_dependency 'eth', '~> 0.5.10'
   spec.add_dependency 'keccak', '~> 1.3', '>= 1.3.1'
-  spec.add_dependency "power-types", "~> 0.1"
+  spec.add_dependency 'power-types', '~> 0.1'
 
-  spec.add_development_dependency "bundler", "~> 2.1"
-  spec.add_development_dependency "guard", "~> 2.14"
-  spec.add_development_dependency "guard-rspec", "~> 4.7"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 3.7.5"
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'guard', '~> 2.14'
+  spec.add_development_dependency 'guard-rspec', '~> 4.7'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'webmock', '~> 3.7.5'
 end

--- a/lib/etherlite.rb
+++ b/lib/etherlite.rb
@@ -56,7 +56,7 @@ module Etherlite
     _url = URI(_url) unless _url.is_a? URI
 
     options = config.default_connection_options
-    options = options.merge _options.slice options.keys
+    options = options.merge _options.slice(*options.keys)
 
     Client.new Connection.new(_url, options)
   end

--- a/lib/etherlite/api/node.rb
+++ b/lib/etherlite/api/node.rb
@@ -60,15 +60,6 @@ module Etherlite
         @anonymous_account ||= Etherlite::Account::Anonymous.new(connection)
       end
 
-      def account_from_pk(_pk)
-        Etherlite.logger.warn(
-          "use of 'account_from_pk' is deprecated and will be removed in next version, \
-use 'load_account' instead"
-        )
-
-        load_account(from_pk: _pk)
-      end
-
       def_delegators :default_account, :unlock, :lock, :normalized_address, :transfer_to, :call
     end
   end

--- a/lib/etherlite/connection.rb
+++ b/lib/etherlite/connection.rb
@@ -3,7 +3,7 @@ module Etherlite
     include Api::Rpc
     include Api::ParityRpc
 
-    attr_reader :chain_id, :use_parity
+    attr_reader :uri, :chain_id, :use_parity
 
     def initialize(_uri, _options = {})
       @uri = _uri

--- a/lib/etherlite/version.rb
+++ b/lib/etherlite/version.rb
@@ -1,3 +1,3 @@
 module Etherlite
-  VERSION = "0.5.3"
+  VERSION = '0.6.0'.freeze
 end

--- a/spec/etherlite_spec.rb
+++ b/spec/etherlite_spec.rb
@@ -5,8 +5,20 @@ describe Etherlite do
     expect(Etherlite::VERSION).not_to be nil
   end
 
-  describe ".connection" do
-    it "returns the default connection" do
+  describe '.connect' do
+    it 'passes the base uri to the new connection' do
+      client = Etherlite.connect('http://foo.bar')
+      expect(client.connection.uri.to_s).to eq 'http://foo.bar'
+    end
+
+    it 'passes the chain_id option to the new connection' do
+      client = Etherlite.connect('http://foo.bar', chain_id: 123)
+      expect(client.connection.chain_id).to eq 123
+    end
+  end
+
+  describe '.connection' do
+    it 'returns the default connection' do
       expect(Etherlite.connection).to be_a Etherlite::Connection
     end
   end

--- a/spec/integration/contract_interaction_spec.rb
+++ b/spec/integration/contract_interaction_spec.rb
@@ -46,7 +46,7 @@ describe 'Test contract interaction', integration: true do
       last_log = contract.get_logs.last
       expect(last_log).to be_a contract_class::TestEvent
       expect(last_log.tx_hash).to eq tx.tx_hash
-      expect(last_log.address.address).to eq contract.address
+      expect(last_log.address.to_s).to eq contract.address
       expect(last_log.int_param).to eq -10
       expect(last_log.uint_param).to eq 30
       expect(last_log.string_param).to eq 'foo'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+
 require 'pry'
 require 'etherlite'
 require 'webmock/rspec'
 
 module SpecExtensions
   extend RSpec::SharedContext
-  let(:client) { Etherlite.connect 'http://localhost:8001' }
+  let(:client) { Etherlite.connect 'http://localhost:8565' }
 
   around(:each) do |example|
     if example.metadata[:integration]
@@ -26,6 +27,5 @@ end
 RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
-  
   config.include SpecExtensions
 end


### PR DESCRIPTION
Esto es necesario para soportar la nueva testnet sepolia.

No rompe directamente la compatibilidad, pero la nueva gema eth si, por eso cambié la versión minor.