### PR TITLE
chore(github): use the built in github token to release and tag

### DIFF
--- a/.github/workflows/test_n_release.yml
+++ b/.github/workflows/test_n_release.yml
@@ -47,16 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate Token
-        uses: tibdex/github-app-token@v2
-        id: generate-token
-        with:
-          app_id: ${{ vars.REPO_GH_APP_ID }}
-          private_key: ${{ secrets.REPO_GH_APP_PRIVATE_KEY }}
-
       - uses: googleapis/release-please-action@v4
-        with:
-          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Me fallo correr el release please porque el GitHub app no tenía permisos para este repositorio. https://github.com/budacom/etherlite/actions/runs/14366534567

Pero eso me hizo pensar que en este caso no es realmente necesario usar la GitHub app, ya que todas las acciones son solo para ejecutarlas contra el mismo repositorio donde corren los workflows. Basta que tenga permisos para crear prs y tagear/release 

